### PR TITLE
Update org name references (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Learn more about Magrathea at https://magrathea.guide.
 
-View the available code here on GitHub at https://github.com/rp-magrathea.
+View the available code here on GitHub at https://github.com/magratheaguide.

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
                 </header>
 
                 <div class="content">
-                    <p>All of the currently available Magrathea codes live as <a href="https://github.com/rp-magrathea/">repositories on GitHub under the Magrathea organization</a>. Only a few callouts will be featured here.</p>
+                    <p>All of the currently available Magrathea codes live as <a href="https://github.com/magratheaguide/">repositories on GitHub under the Magrathea organization</a>. Only a few callouts will be featured here.</p>
 
                     <aside>
                         If you’re not familiar with GitHub, there are a lot of great learning resources out there, including GitHub’s own <a href="https://help.github.com/en/github">documentation</a> and <a href="https://lab.github.com/githubtraining/introduction-to-github">Learning Lab</a>
@@ -313,11 +313,11 @@
                         </header>
                         
                         <div class="content">                            
-                            <p><a href="https://github.com/rp-magrathea/vogsphere">Vogsphere</a> is a tool that enables you to create a claims form on your site. Instead of editing code, your members can just fill out that form to generate exactly what they need to post to make their claims. No more code typos for you to deal with, no more trying to sift through code for them. Win-win.</p>
+                            <p><a href="https://github.com/magratheaguide/vogsphere">Vogsphere</a> is a tool that enables you to create a claims form on your site. Instead of editing code, your members can just fill out that form to generate exactly what they need to post to make their claims. No more code typos for you to deal with, no more trying to sift through code for them. Win-win.</p>
 
                             <ul class="feature-icons">
                                 <li class="icon solid fa-code">
-                                    <a href="https://github.com/rp-magrathea/vogsphere">Learn more</a>
+                                    <a href="https://github.com/magratheaguide/vogsphere">Learn more</a>
                                 </li>
                                 <li class="icon solid fa-laptop-code">
                                     <a href="https://magrathea.guide/vogsphere/src/vogsphere.html">Try the demo</a>
@@ -746,7 +746,7 @@
                                     <li>
                                         <a 
                                             aria-label="Magrathea on GitHub"
-                                            href="https://github.com/rp-magrathea" 
+                                            href="https://github.com/magratheaguide" 
                                             class="icon brands fa-github"
                                             title="Magrathea on GitHub"
                                         >


### PR DESCRIPTION
The GitHub org name has changed from `rp-magrathea` to `magratheaguide`. All URLs need to be updated accordingly.