### PR TITLE
Update license years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2022 Magrathea (https://magrathea.guide).
+Copyright 2020–2023 Magrathea (https://magrathea.guide).
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Now that there are commits in 2023, the license needs to be updated to reflect that.

Looks like there were also commits in 2020 and 2021 that the license was missing, so those years have been added as well.